### PR TITLE
fix: 🐛 取得order資料時使用total

### DIFF
--- a/src/features/order-detail/order-detail.service.ts
+++ b/src/features/order-detail/order-detail.service.ts
@@ -250,7 +250,7 @@ export class OrderDetailService {
           ),
           create_time: detail.create_time,
         })),
-        total: order.final_total,
+        total: order.total,
       };
 
       return result;


### PR DESCRIPTION
- [x] 取得order資料時改取total
![image](https://github.com/alphatero/siau-kha-backend/assets/59496575/94f04e94-c811-4a03-9c55-57315f99addd)
